### PR TITLE
feat: add Go language support to the default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,16 @@ require("fold_imports").setup({
       filetypes = { "zig" },
       patterns = { "*.zig" },
     },
+    go = {
+      enabled = true,
+      parsers = { "go" },
+      queries = {
+        "(import_declaration) @import",
+        "(import_spec) @import"
+      },
+      filetypes = { "go" },
+      patterns = { "*.go" },
+    },
   },
 })
 ```
@@ -250,6 +260,11 @@ fold_imports.toggle()
 
 - **Supported**: Variable declarations with @import builtin
 - **Examples**: `const std = @import("std");`
+
+### go
+
+- **Supported**: Import statements
+- **Examples**: `import fmt`
 
 ## Troubleshooting
 

--- a/lua/fold_imports.lua
+++ b/lua/fold_imports.lua
@@ -96,6 +96,16 @@ local default_config = {
       filetypes = { "python" },
       patterns = { "*.py", "*.pyi" },
     },
+    go = {
+      enabled = true,
+      parsers = { "go" },
+      queries = {
+        "(import_declaration) @import", -- For import blocks
+        "(import_spec) @import",        -- For individual imports within blocks
+      },
+      filetypes = { "go" },
+      patterns = { "*.go" },
+    },
   },
 }
 
@@ -562,7 +572,7 @@ function M._get_fold_text()
     local fill_char = vim.opt.fillchars:get().fold or "-"
 
     return string.format("+%s %s ", string.rep(fill_char, 2), fold_text)
-      .. string.rep(fill_char, math.max(0, fill_count))
+        .. string.rep(fill_char, math.max(0, fill_count))
   else
     return vim.fn.foldtext()
   end


### PR DESCRIPTION
not much just adding go to the default configuration list
- Add Go to supported languages with import_declaration query
- Supports import blocks
- Tested with various Go import patterns