### PR TITLE
fix: Reload buffer after fold toggle

### DIFF
--- a/lua/fold_imports.lua
+++ b/lua/fold_imports.lua
@@ -99,7 +99,7 @@ local default_config = {
       parsers = { "go" },
       queries = {
         "(import_declaration) @import", -- For import blocks
-        "(import_spec) @import",        -- For individual imports within blocks
+        "(import_spec) @import", -- For individual imports within blocks
       },
       filetypes = { "go" },
       patterns = { "*.go" },
@@ -505,7 +505,7 @@ function M.setup(user_config)
     config.enabled = not config.enabled
     setup_autocommands()
     -- Reload current buffer
-    vim.cmd('edit')
+    vim.cmd("edit")
     print("FoldImports " .. (config.enabled and "enabled" or "disabled"))
   end, { desc = "Toggle fold imports plugin" })
 
@@ -572,7 +572,7 @@ function M._get_fold_text()
     local fill_char = vim.opt.fillchars:get().fold or "-"
 
     return string.format("+%s %s ", string.rep(fill_char, 2), fold_text)
-        .. string.rep(fill_char, math.max(0, fill_count))
+      .. string.rep(fill_char, math.max(0, fill_count))
   else
     return vim.fn.foldtext()
   end

--- a/lua/fold_imports.lua
+++ b/lua/fold_imports.lua
@@ -99,7 +99,7 @@ local default_config = {
       parsers = { "go" },
       queries = {
         "(import_declaration) @import", -- For import blocks
-        "(import_spec) @import", -- For individual imports within blocks
+        "(import_spec) @import",        -- For individual imports within blocks
       },
       filetypes = { "go" },
       patterns = { "*.go" },
@@ -504,6 +504,8 @@ function M.setup(user_config)
   vim.api.nvim_create_user_command("FoldImportsToggle", function()
     config.enabled = not config.enabled
     setup_autocommands()
+    -- Reload current buffer
+    vim.cmd('edit')
     print("FoldImports " .. (config.enabled and "enabled" or "disabled"))
   end, { desc = "Toggle fold imports plugin" })
 
@@ -570,7 +572,7 @@ function M._get_fold_text()
     local fill_char = vim.opt.fillchars:get().fold or "-"
 
     return string.format("+%s %s ", string.rep(fill_char, 2), fold_text)
-      .. string.rep(fill_char, math.max(0, fill_count))
+        .. string.rep(fill_char, math.max(0, fill_count))
   else
     return vim.fn.foldtext()
   end


### PR DESCRIPTION
Automatically reloads the current buffer after toggling to immediately reflect folding changes without requiring manual refresh.
Changes:

Added vim.cmd('edit') to reload buffer and apply fold state changes instantly